### PR TITLE
Asma/fix source writing/head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,11 @@ cython_debug/
 # image files
 *.png
 
+# more to ignore
+booster_slurm_atmorep_evaluate.sh
+booster_slurm_atmorep_train.sh
+data
+hdfml_slurm_atmorep_evaluate.sh
+logs/
+models/
+wandb/

--- a/atmorep/config/config.py
+++ b/atmorep/config/config.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 fpath = os.path.dirname(os.path.realpath(__file__))
 
-path_models = Path( fpath, '../../models/')
-path_results = Path( fpath, '../../results')
-path_plots = Path( fpath, '../results/plots/')
+path_models = Path( fpath, '/p/scratch/deepacf/semcheddine1/atmorep_temporal_interpolation/models/')
+path_results = Path( fpath, '/p/scratch/deepacf/semcheddine1/atmorep_temporal_interpolation/results')
+path_plots = Path( fpath, '/p/scratch/deepacf/semcheddine1/atmorep_temporal_interpolation/results/plots/')
 
 grib_index = { 'vorticity' : 'vo', 'divergence' : 'd', 'geopotential' : 'z',
                 'orography' : 'z', 'temperature': 't', 'specific_humidity' : 'q',

--- a/atmorep/core/evaluate.py
+++ b/atmorep/core/evaluate.py
@@ -24,10 +24,10 @@ if __name__ == '__main__':
   #model_id = 'oxpycr7w'     # divergence
   #model_id = '1565pb1f'     # specific_humidity
   #model_id = '3kdutwqb'     # total precip
-  model_id = 'dys79lgw'     # velocity_u
+  # model_id = 'dys79lgw'     # velocity_u
   #model_id = '22j6gysw'     # velocity_v
   # model_id = '15oisw8d'     # velocity_z
-  #model_id = '3qou60es'     # temperature (also 2147fkco)
+  model_id = '3qou60es'     # temperature (also 2147fkco)
   #model_id = '2147fkco'     # temperature (also 2147fkco)
  
   # multi-field configurations with either velocity or voritcity+divergence
@@ -67,7 +67,8 @@ if __name__ == '__main__':
 #                                       'forecast_num_tokens' : 2,
 #                                       'with_pytest' : True }
 
-  file_path = '/gpfs/scratch/ehpc03/era5_y2010_2021_res025_chunk8.zarr'
+  # file_path = '/gpfs/scratch/ehpc03/era5_y2010_2021_res025_chunk8.zarr'
+  file_path = '/p/scratch/atmo-rep/data/era5_1deg/months/era5_y2021_res025_chunk8.zarr' 
   
   now = time.time()
   Evaluator.evaluate( mode, model_id, file_path, options)

--- a/atmorep/core/evaluator.py
+++ b/atmorep/core/evaluator.py
@@ -130,6 +130,9 @@ class Evaluator( Trainer_BERT) :
     cf.BERT_strategy = 'BERT'
     cf.log_test_num_ranks = 4
     cf.num_samples_validate = 10 #28 #1472 
+    years = [2021]
+    years_test = [2021]
+    cf.years_val = [2021]
     Evaluator.parse_args( cf, args)
     utils.check_num_samples(cf.num_samples_validate, cf.batch_size)
     Evaluator.run( cf, model_id, model_epoch, devices)

--- a/atmorep/core/train.py
+++ b/atmorep/core/train.py
@@ -218,7 +218,8 @@ def train() :
   # # # cf.file_path = '/p/scratch/atmo-rep/data/era5_1deg/months/era5_y2021_res025_chunk8.zarr'
   # # cf.file_path = '/ec/res4/scratch/nacl/atmorep/era5_y2021_res025_chunk8_lat180_lon180.zarr'
   # # # cf.file_path = '/ec/res4/scratch/nacl/atmorep/era5_y2021_res025_chunk16.zarr'
-  cf.file_path = '/gpfs/scratch/ehpc03/era5_y2010_2021_res025_chunk8.zarr/'
+  # cf.file_path = '/gpfs/scratch/ehpc03/era5_y2010_2021_res025_chunk8.zarr/'
+  cf.file_path = '/p/scratch/atmo-rep/data/era5_1deg/months/era5_y2010_2021_res025_chunk8.zarr' # Asma: added cuz couldn't find it in the list
   # # # in steps x lat_degrees x lon_degrees
   cf.n_size = [36, 0.25*9*6, 0.25*9*12]
 

--- a/atmorep/datasets/data_writer.py
+++ b/atmorep/datasets/data_writer.py
@@ -102,6 +102,17 @@ def write_BERT( model_id, epoch, batch_idx, levels, sources,
 
   zarr_store = getattr( zarr, zarr_store_type)
 
+  # store_source = zarr_store( fname.format( 'source'))
+  # exp_source = zarr.group(store=store_source)
+  # for fidx, field in enumerate(sources) :
+  #   ds_field = exp_source.require_group( f'{field[0]}')
+  #   batch_size = field[1].shape[0]
+  #   for bidx in range( field[1].shape[0]) :
+  #     sample = batch_idx * batch_size + bidx
+  #     write_item(ds_field, sample, field[1][bidx], levels[fidx], sources_coords[fidx][bidx] )
+  # store_source.close()
+
+
   store_source = zarr_store( fname.format( 'source'))
   exp_source = zarr.group(store=store_source)
   for fidx, field in enumerate(sources) :
@@ -109,7 +120,9 @@ def write_BERT( model_id, epoch, batch_idx, levels, sources,
     batch_size = field[1].shape[0]
     for bidx in range( field[1].shape[0]) :
       sample = batch_idx * batch_size + bidx
-      write_item(ds_field, sample, field[1][bidx], levels[fidx], sources_coords[fidx][bidx] )
+      ds_source_b = ds_field.create_group( f'sample={sample:05d}')
+      for vidx in range(len(levels[fidx])) :
+        write_item(ds_source_b, levels[fidx][vidx], field[1][bidx][vidx], levels[fidx][vidx], sources_coords[fidx][bidx], name = 'ml' )
   store_source.close()
 
   store_target = zarr_store( fname.format( 'target'))

--- a/atmorep/tests/test_utils.py
+++ b/atmorep/tests/test_utils.py
@@ -1,14 +1,23 @@
 import numpy as np
 import pandas as pd 
 
+# def era5_fname():
+#     return "/gpfs/scratch/ehpc03/data/{}/ml{}/era5_{}_y{}_m{}_ml{}.grib"
+
+# def atmorep_pred():
+#     return "./results/id{}/results_id{}_epoch{}_pred.zarr"
+
+# def atmorep_target():
+#     return "./results/id{}/results_id{}_epoch{}_target.zarr"
+
 def era5_fname():
-    return "/gpfs/scratch/ehpc03/data/{}/ml{}/era5_{}_y{}_m{}_ml{}.grib"
+    return "/p/scratch/atmo-rep/data/era5/new_structure/{}/ml{}/era5_{}_y{}_m{}_ml{}.grib"
 
 def atmorep_pred():
-    return "./results/id{}/results_id{}_epoch{}_pred.zarr"
+    return "/p/scratch/deepacf/semcheddine1/atmorep_temporal_interpolation/results/id{}/results_id{}_epoch{}_pred.zarr"
 
 def atmorep_target():
-    return "./results/id{}/results_id{}_epoch{}_target.zarr"
+    return "/p/scratch/deepacf/semcheddine1/atmorep_temporal_interpolation/results/id{}/results_id{}_epoch{}_target.zarr"
 
 def grib_index(field):
     grib_idxs = {"velocity_u": "u",


### PR DESCRIPTION
This PR is related to the issue " source and target not written the same way in BERT mode #38".  The data is now accessed the same way. However, I keep having the following test failure:

```
0: =================================== FAILURES ===================================
0: ________________________________ test_datetime _________________________________
0: 
0: field = 'temperature', model_id = '1rj15n6y', BERT = True, epoch = 0
0: 
0:     def test_datetime(field, model_id, BERT, epoch = 0):
0:     
0:         """
0:         Check against ERA5 timestamps.
0:         Loop over all levels individually. 50 random samples for each level.
0:         """
0:     
0:         store = zarr.ZipStore(atmorep_target().format(model_id, model_id, str(epoch).zfill(5)))
0:         atmorep = zarr.group(store)
0:     
0:         nsamples = min(len(atmorep[field]), 50)
0:         samples = rnd.sample(range(len(atmorep[field])), nsamples)
0:         levels = [int(f.split("=")[1]) for f in atmorep[f"{field}/sample=00000"]] if BERT else atmorep[f"{field}/sample=00000"].ml[:]
0:     
0:         get_data = get_BERT if BERT else get_forecast
0:     
0:         for level in levels:
0:             #TODO: make it more elegant
0:             level_idx = level if BERT else np.where(levels == level)[0].tolist()[0]
0:     
0:             for s in samples:
0:                 data, datetime, lats, lons = get_data(atmorep, field, s, level_idx)
0:                 year, month = datetime.year, str(datetime.month).zfill(2)
0:     
0:                 era5_path = era5_fname().format(field, level, field, year, month, level)
0:                 if not os.path.isfile(era5_path):
0:                     warnings.warn(UserWarning((f"Timestamp {datetime} not found in ERA5. Skipping")))
0:                     continue
0:                 era5 = xr.open_dataset(era5_path, engine = "cfgrib")[grib_index(field)].sel(time = datetime, latitude = lats, longitude = lons)
0:     
0:                 #assert (data[0] == era5.values[0]).all(), "Mismatch between ERA5 and AtmoRep Timestamps"
0: >               assert np.isclose(data[0], era5.values[0],rtol=1e-04, atol=1e-07).all(), "Mismatch between ERA5 and AtmoRep Timestamps"
0: E               AssertionError: Mismatch between ERA5 and AtmoRep Timestamps
0: E               assert False
0: E                +  where False = <built-in method all of numpy.ndarray object at 0x147d686952f0>()
0: E                +    where <built-in method all of numpy.ndarray object at 0x147d686952f0> = array([False, False, False, False, False, False, False, False, False,\n       False, False, False, False, False, False, False, False, False,\n       False, False, False, False, False, False, False, False, False]).all
0: E                +      where array([False, False, False, False, False, False, False, False, False,\n       False, False, False, False, False, False, False, False, False,\n       False, False, False, False, False, False, False, False, False]) = <function isclose at 0x147e9c4e20b0>(array([267.93634, 267.91095, 267.89044, 267.92853, 267.97052, 268.0135 ,\n       268.02228, 267.88556, 267.6668 , 267.3...6.00275, 266.50568, 266.6678 , 266.28107, 265.575  , 265.5174 ,\n       265.79083, 265.90997, 266.15704], dtype=float32), array([265.21954, 266.00275, 266.50568, 266.6678 , 266.28107, 265.575  ,\n       265.5174 , 265.79083, 265.90997, 266.1...7.6668 , 267.33966, 266.92853, 266.47345, 266.09454, 265.84747,\n       265.57306, 265.21564, 264.91193], dtype=float32), rtol=0.0001, atol=1e-07)
0: E                +        where <function isclose at 0x147e9c4e20b0> = np.isclose
0: 
0: /p/home/jusers/semcheddine1/juwels/2_atmorep_dev/atmorep/atmorep/tests/validation_test.py:68: AssertionError
```
Might be related to the dataset not being loaded properly (I am unsure if this is what you meant @iluise during our first temporal interpolation meeting)