### PR TITLE
fix bug with hardcoded maximum of supported vertical levels

### DIFF
--- a/atmorep/core/trainer.py
+++ b/atmorep/core/trainer.py
@@ -536,8 +536,8 @@ class Trainer_BERT( Trainer_Base) :
     self.rng_seed = cf.rng_seed
     if not self.rng_seed :
       self.rng_seed = int(torch.randint( 100000000, (1,))) 
-    # TODO: generate only rngs that are needed
-    ll = len(cf.fields) * 8 #len(cf.vertical_levels)
+    # generate rngs up to fields times max configured levels among fields plus one
+    ll = len(cf.fields) * (max([len(f[2]) for f in cf.fields])+1)
     if cf.BERT_fields_synced :
       self.rngs = [np.random.default_rng(self.rng_seed) for _ in range(ll)]
     else : 


### PR DESCRIPTION
## Description
Replaced hardcoded generation of "rngs" in trainer.py for support of up to 7 vertical levels by a flexible version that generates rngs up to the maximum number of vertical levels among provided fields.

## Related Issue
[[BUG] training fails with increased number of levels #66 ](https://github.com/clessig/atmorep/issues/66)

## Motivation and Context
Need more room and flexibility for an increased number of vertical levels per field

## How Has This Been Tested?
running train_multi.py with this config works ([run on wandb](https://wandb.ai/atmorep/stratorep/runs/lz6y5o3e/overview)):
```
  cf.fields = [ 
                [ 'velocity_u', [ 1, 1024, ['velocity_v', 'temperature'], 0 ], 
                                [ 96, 105, 114, 123, 137 ], 
                                [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05] ],
                [ 'velocity_v', [ 1, 1024, ['velocity_u', 'temperature'], 1 ], 
                                [ 96, ], 
                                [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05] ], 
                [ 'specific_humidity', [ 1, 1024, ['velocity_u', 'velocity_v', 'temperature'], 2 ], 
                              [ 96, 105, 114, ], 
                              [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05] ],
                [ 'velocity_z', [ 1, 1024, ['velocity_u', 'velocity_v', 'temperature'], 3 ], 
                              [ 96, 105, 114, 123 ], 
                              [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05] ],
                 [ 'temperature', [ 1, 1024, ['velocity_u', 'velocity_v', 'specific_humidity'], 3 ], 
                              [ 96, 105, ], 
                              [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05], 'local' ],
              ]
```
Running train.py with this config also works ([run on wandb](https://wandb.ai/atmorep/stratorep/runs/ugkgfp2f/overview)):
```
  cf.fields = [ [ 'temperature', [ 1, 1024, [ ], 0 ], 
                               [ 23, 29, 41, 53, 60, 96, 105, 114, 123, 137
                                ], 
                               [12, 2, 4], [3, 27, 27], [0.5, 0.9, 0.2, 0.05], 'local' ] ]
  cf.fields_prediction = [ [cf.fields[0][0], 1.] ]
```