### PR TITLE
refactor normalisation class to handle log_transform 

### DIFF
--- a/atmorep/config/config.py
+++ b/atmorep/config/config.py
@@ -12,4 +12,4 @@ path_plots   = Path( fpath, '../results/plots/')
 #ATOS: path = /ec/res4/scratch/nacl/atmorep/
 #JSC : path = /p/scratch/atmo-rep/data/era5_1deg/months/
 #BSC : path = /gpfs/scratch/ehpc03/
-path_data    = ('./data/era5_y1979_2021_res025_chunk8.zarr/')
+path_data    = ('./data/era5_y2010_2021_res025_chunk8.zarr/')

--- a/atmorep/core/atmorep_model.py
+++ b/atmorep/core/atmorep_model.py
@@ -113,7 +113,7 @@ class AtmoRepData( torch.nn.Module) :
       assert False
 
   ###################################################
-  def normalizer( self, field, vl_idx, lats_idx, lons_idx ) :
+  def normalizer( self, field, vl_idx ) :
 
     if isinstance( field, str) :
       for fidx, field_info in enumerate(self.cf.fields) :
@@ -124,14 +124,12 @@ class AtmoRepData( torch.nn.Module) :
 
     elif isinstance( field, int) :
       normalizer = self.dataset_train.normalizers[field][vl_idx]
-      if len(normalizer.shape) > 2:
-        normalizer = np.take( np.take( normalizer, lats_idx, -2), lons_idx, -1)
     else :
       assert False, 'invalid argument type (has to be index to cf.fields or field name)'
     
     year_base = self.dataset_train.year_base
 
-    return normalizer, year_base
+    return normalizer #, year_base
 
   ###################################################
   def mode( self, mode : NetMode) :

--- a/atmorep/core/evaluate.py
+++ b/atmorep/core/evaluate.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
   #model_id='v63l01zu' #specific humidity 
   #model_id='9l1errbo' #velocity_z
   model_id='7ojls62c' #temperature 1024 
-  
+  # model_id = 'ztul6nxn' 
   # supported modes: test, forecast, fixed_location, temporal_interpolation, global_forecast,
   #                  global_forecast_range
   # options can be used to over-write parameters in config; some modes also have specific options, 
@@ -58,14 +58,15 @@ if __name__ == '__main__':
   mode, options = 'global_forecast', { 
                                       #'dates' : [[2021, 2, 10, 12]]
                                       'dates' : [
-                                         [2021, 1, 10, 12] , [2021, 1, 11, 0], [2021, 1, 11, 12], [2021, 1, 12, 0], #[2021, 1, 12, 12], [2021, 1, 13, 0], 
-                                         [2021, 4, 10, 12], [2021, 4, 11, 0], [2021, 4, 11, 12], [2021, 4, 12, 0], #[2021, 4, 12, 12], [2021, 4, 13, 0], 
-                                         [2021, 7, 10, 12], [2021, 7, 11, 0], [2021, 7, 11, 12], [2021, 7, 12, 0], #[2021, 7, 12, 12], [2021, 7, 13, 0], 
-                                         [2021, 10, 10, 12], [2021, 10, 11, 0], [2021, 10, 11, 12], #[2021, 10, 12, 0], [2021, 10, 12, 12], [2021, 10, 13, 0]
+                                         [2021, 1, 10, 12] #, [2021, 1, 11, 0], [2021, 1, 11, 12], [2021, 1, 12, 0], #[2021, 1, 12, 12], [2021, 1, 13, 0], 
+                                         #[2021, 4, 10, 12], [2021, 4, 11, 0], [2021, 4, 11, 12], [2021, 4, 12, 0], #[2021, 4, 12, 12], [2021, 4, 13, 0], 
+                                         #[2021, 7, 10, 12], [2021, 7, 11, 0], [2021, 7, 11, 12], [2021, 7, 12, 0], #[2021, 7, 12, 12], [2021, 7, 13, 0], 
+                                         #[2021, 10, 10, 12], [2021, 10, 11, 0], [2021, 10, 11, 12], #[2021, 10, 12, 0], [2021, 10, 12, 12], [2021, 10, 13, 0]
                                        ], 
                                       'token_overlap' : [0, 0],
                                       'forecast_num_tokens' : 2,
-                                      'with_pytest' : True }
+                                      'with_pytest' : True, 
+                                       }
   
   now = time.time()
   Evaluator.evaluate( mode, model_id, options)

--- a/atmorep/core/train.py
+++ b/atmorep/core/train.py
@@ -107,7 +107,13 @@ def train() :
  
   cf.fields = [ [ 'velocity_u', [ 1, 1024, [ ], 0 ], 
                                 [ 96, 105, 114, 123, 137 ], 
-                                 [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05] ] ]
+                                 [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05],  {'corr_type' : 'local'} ] ]
+
+  cf.fields_prediction = [ [cf.fields[0][0], 1.] ]
+
+  cf.fields = [ [ 'total_precip', [ 1, 1024, [ ], 0 ], 
+                                [0], 
+                                 [12, 3, 6], [3, 18, 18], [0.5, 0.9, 0.2, 0.05],  {'corr_type' : 'global', 'log_transform' : True, 'eps': 1e-7 } ] ]
 
   cf.fields_prediction = [ [cf.fields[0][0], 1.] ]
 

--- a/atmorep/datasets/normalizer.py
+++ b/atmorep/datasets/normalizer.py
@@ -16,67 +16,101 @@
 
 import code
 import numpy as np
-import xarray as xr
 import atmorep.config.config as config
+from atmorep.utils.utils import log_transform, invert_log_transform
 
 ######################################################
 #                   Normalize                        #
 ######################################################
 
-def normalize( data, norm, dates, year_base = 1979) :
-  corr_data = np.array([norm[12*(dt.year-year_base) + dt.month-1] for dt in dates])
-  mean, var = corr_data[:, 0], corr_data[:, 1]
-  if (var == 0.).all() :
-    print( f'Warning: var == 0') 
-    assert False
-  if len(norm.shape) > 2 : #global norm
-    return normalize_local(data, mean, var)
-  else:
-    return normalize_global( data, mean, var)
+class Normalizer(object):
+
+  def __init__(self, norm, type, eps = 1e-6, year_base = 1979, log_tr = False):
+    self.type = type
+    self.year_base = year_base
+    self.log_tr = log_tr
+    self.norm = norm
+    self.eps = eps
+
+  def get_norm(self, lat_ran, lon_ran):
+    if self.type != 'global':  
+      if lat_ran[0] < lat_ran[-1] and lon_ran[0] < lon_ran[-1]:
+        lat_max, lat_min = max(lat_ran), min(lat_ran)
+        lon_max, lon_min = max(lon_ran), min(lon_ran)
+        # print(lat_min, lat_max, lon_min, lon_max)
+        return self.norm[:,:,lat_min:lat_max+1,lon_min:lon_max+1]
+      else:
+        return self.norm[ ... , lat_ran[:,np.newaxis], lon_ran[np.newaxis,:]]
+    else:
+      return self.norm
+
+  def normalize(self, data, dates, lat_idxs, lon_idxs) : 
+    # breakpoint()
+    norm_sel = self.get_norm(lat_idxs, lon_idxs)
+    corr_data = np.array([norm_sel[12*(dt.year-self.year_base) + dt.month-1] for dt in dates])
+    mean, var = corr_data[:, 0], corr_data[:, 1]
+    if (var == 0.).all() :
+      print( f'Warning: var == 0') 
+      assert False
+
+    if self.log_tr:
+      data = log_transform(data, eps = self.eps)
   
-######################################################
-def normalize_local( data, mean, var) :
-  data = (data - mean) / var
-  return data
+    if self.type == 'global': 
+      return self.normalize_global(data, mean, var)
+    else:
+      return self.normalize_local( data, mean, var)
+  
+  ######################################################
+  def normalize_local(self, data, mean, var) :
+    # breakpoint()
+    data = (data - mean) / var
+    return data
 
-######################################################
-def normalize_global( data, mean, var) :
-  for i in range( data.shape[0]) :
-    data[i] = (data[i] - mean[i]) / var[i]
-  return data
-
-
-######################################################
-#                  Denormalize                       #
-######################################################
-def denormalize(data, norm, dates, year_base = 1979) :
-  corr_data = np.array([norm[12*(dt.year-year_base) + dt.month-1] for dt in dates])
-  mean, var = corr_data[:, 0], corr_data[:, 1]
-  if len(norm.shape) > 2 :
-    return denormalize_local(data, mean, var)
-  else:
-    return denormalize_global(data, mean, var)  
-
-######################################################
-
-def denormalize_local(data, mean, var) :
-  if len(data.shape) > 3: #ensemble
+  ######################################################
+  def normalize_global(self, data, mean, var) :
     for i in range( data.shape[0]) :
-      data[i] = (data[i] * var) + mean
-  else:
-      data = (data * var) + mean
-  return data
+      data[i] = (data[i] - mean[i]) / var[i]
+    return data
 
-######################################################
 
-def denormalize_global(data, mean, var) :
-  if len(data.shape) > 3: #ensemble
-    data = data.swapaxes(0,1)
-    for i in range( data.shape[0]) :
-      data[i] = ((data[i] * var[i]) + mean[i])
-    data = data.swapaxes(0,1)
-  else:
-    for i in range( data.shape[0]) :
-      data[i] = (data[i] * var[i]) + mean[i]
+  ######################################################
+  #                  Denormalize                       #
+  ######################################################
+  def denormalize(self, data, dates, lat_idxs, lon_idxs): 
+    norm_sel = self.get_norm(lat_idxs, lon_idxs)
+    corr_data = np.array([norm_sel[12*(dt.year-self.year_base) + dt.month-1] for dt in dates])
+    mean, var = corr_data[:, 0], corr_data[:, 1]
+    if self.type == 'global': #len(norm.shape) > 2 :
+      data = self.denormalize_global(data, mean, var)
+    else:
+      data = self.denormalize_local(data, mean, var)  
+  
+    if self.log_tr:
+      data = invert_log_transform(data, eps = self.eps)
+  
+    return data
+
+  ######################################################
+
+  def denormalize_local(self, data, mean, var) :
+    if len(data.shape) > 3: #ensemble
+      for i in range( data.shape[0]) :
+        data[i] = (data[i] * var) + mean
+    else:
+        data = (data * var) + mean
+    return data
+
+  ######################################################
+
+  def denormalize_global(self, data, mean, var) :
+    if len(data.shape) > 3: #ensemble
+      data = data.swapaxes(0,1)
+      for i in range( data.shape[0]) :
+        data[i] = ((data[i] * var[i]) + mean[i])
+      data = data.swapaxes(0,1)
+    else:
+      for i in range( data.shape[0]) :
+        data[i] = (data[i] * var[i]) + mean[i]
     
-  return data
+    return data

--- a/atmorep/utils/utils.py
+++ b/atmorep/utils/utils.py
@@ -416,3 +416,13 @@ def unique_unsorted(x):
   x_flattened = x.flatten() 
   _, x_idx = np.unique(x_flattened, return_index=True)
   return x_flattened[np.sort(x_idx)]
+
+########################################
+
+def log_transform(data, eps = 0.001):
+  return np.log(data + eps) - np.log(eps)
+
+########################################
+
+def invert_log_transform(data, eps = 0.001):
+  return np.exp( data + np.log(eps)) - eps


### PR DESCRIPTION
the MR contains the following changes: 
- refactored the normalisation and moved to a dedicated class. 
- moved all options related to normalisations into a dictionary
- fully backward compatible with the old fields

example: 
- for total_precip add the following option:  {'corr_type' : 'global', 'log_transform' : True, 'eps': 1e-7 } 

solving issue: https://github.com/clessig/atmorep/issues/84

@mlangguth89 to be used for `ztul6nxn` and `o5n1xbxj`. please add the dictionary to the .json file as these runs were trained before I implemented this. 
